### PR TITLE
chore: upgrade golangci-lint to v2.12.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.8.0
+GOLANGCI_LINT_VERSION ?= v2.12.1
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/internal/common/git_sync.go
+++ b/internal/common/git_sync.go
@@ -19,6 +19,9 @@ const (
 	gitSyncLink                = "current"
 	// Use official git-sync image instead of expecting binary in NiFi image
 	gitSyncImage = "registry.k8s.io/git-sync/git-sync:v4.2.1"
+	// Default values used when GitSyncSpec fields are empty.
+	defaultGitBranch   = "main"
+	defaultGitSyncWait = "20s"
 )
 
 // GitSyncResources holds all Kubernetes resources generated from GitSyncSpec entries.
@@ -138,7 +141,7 @@ func buildGitSyncContainer(
 func buildGitSyncArgs(gs *nifiv1alpha1.GitSyncSpec, oneTime bool) []string {
 	branch := gs.Branch
 	if branch == "" {
-		branch = "main"
+		branch = defaultGitBranch
 	}
 	depth := gs.Depth
 	if depth == 0 {
@@ -146,7 +149,7 @@ func buildGitSyncArgs(gs *nifiv1alpha1.GitSyncSpec, oneTime bool) []string {
 	}
 	wait := gs.Wait
 	if wait == "" {
-		wait = "20s"
+		wait = defaultGitSyncWait
 	}
 
 	// Build args for official git-sync v4.x

--- a/internal/common/git_sync_test.go
+++ b/internal/common/git_sync_test.go
@@ -8,6 +8,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	testRepoURL       = "https://github.com/example/repo"
+	testGitBranch     = "main"
+	testGitSyncWait   = "20s"
+	testGitSecretName = "my-git-secret"
+)
+
 func TestNewGitSyncResources_Empty(t *testing.T) {
 	resources, err := NewGitSyncResources(nil)
 	if err != nil {
@@ -37,11 +44,11 @@ func TestNewGitSyncResources_Empty(t *testing.T) {
 func TestNewGitSyncResources_SingleEntry_Defaults(t *testing.T) {
 	gitSyncs := []nifiv1alpha1.GitSyncSpec{
 		{
-			Repo:      "https://github.com/example/repo",
-			Branch:    "main",
+			Repo:      testRepoURL,
+			Branch:    testGitBranch,
 			Depth:     1,
 			GitFolder: "/",
-			Wait:      "20s",
+			Wait:      testGitSyncWait,
 		},
 	}
 
@@ -114,11 +121,11 @@ func TestNewGitSyncResources_CredentialsSecret(t *testing.T) {
 	gitSyncs := []nifiv1alpha1.GitSyncSpec{
 		{
 			Repo:              "https://github.com/private/repo",
-			Branch:            "main",
+			Branch:            testGitBranch,
 			Depth:             1,
 			GitFolder:         "/",
-			Wait:              "20s",
-			CredentialsSecret: "my-git-secret",
+			Wait:              testGitSyncWait,
+			CredentialsSecret: testGitSecretName,
 		},
 	}
 
@@ -131,12 +138,12 @@ func TestNewGitSyncResources_CredentialsSecret(t *testing.T) {
 	for _, e := range resources.GitSyncContainers[0].Env {
 		switch e.Name {
 		case "GITSYNC_USERNAME":
-			if e.ValueFrom.SecretKeyRef.Name != "my-git-secret" || e.ValueFrom.SecretKeyRef.Key != "user" {
+			if e.ValueFrom.SecretKeyRef.Name != testGitSecretName || e.ValueFrom.SecretKeyRef.Key != "user" {
 				t.Errorf("GITSYNC_USERNAME has wrong secret ref: %+v", e.ValueFrom)
 			}
 			found["GITSYNC_USERNAME"] = true
 		case "GITSYNC_PASSWORD":
-			if e.ValueFrom.SecretKeyRef.Name != "my-git-secret" || e.ValueFrom.SecretKeyRef.Key != "password" {
+			if e.ValueFrom.SecretKeyRef.Name != testGitSecretName || e.ValueFrom.SecretKeyRef.Key != "password" {
 				t.Errorf("GITSYNC_PASSWORD has wrong secret ref: %+v", e.ValueFrom)
 			}
 			found["GITSYNC_PASSWORD"] = true
@@ -152,7 +159,7 @@ func TestNewGitSyncResources_CredentialsSecret(t *testing.T) {
 
 func TestNewGitSyncResources_NoCredentials_NoEnvVars(t *testing.T) {
 	gitSyncs := []nifiv1alpha1.GitSyncSpec{
-		{Repo: "https://github.com/public/repo", Branch: "main", Depth: 1, GitFolder: "/", Wait: "20s"},
+		{Repo: "https://github.com/public/repo", Branch: testGitBranch, Depth: 1, GitFolder: "/", Wait: testGitSyncWait},
 	}
 	resources, err := NewGitSyncResources(gitSyncs)
 	if err != nil {
@@ -165,7 +172,7 @@ func TestNewGitSyncResources_NoCredentials_NoEnvVars(t *testing.T) {
 
 func TestNewGitSyncResources_OneTimeFlag(t *testing.T) {
 	gitSyncs := []nifiv1alpha1.GitSyncSpec{
-		{Repo: "https://github.com/example/repo", Branch: "main", Depth: 1, GitFolder: "/", Wait: "20s"},
+		{Repo: testRepoURL, Branch: testGitBranch, Depth: 1, GitFolder: "/", Wait: testGitSyncWait},
 	}
 	resources, err := NewGitSyncResources(gitSyncs)
 	if err != nil {
@@ -199,7 +206,7 @@ func TestNewGitSyncResources_OneTimeFlag(t *testing.T) {
 
 func TestNewGitSyncResources_EmptyDirVolume(t *testing.T) {
 	gitSyncs := []nifiv1alpha1.GitSyncSpec{
-		{Repo: "https://github.com/example/repo", Branch: "main", Depth: 1, GitFolder: "/", Wait: "20s"},
+		{Repo: testRepoURL, Branch: testGitBranch, Depth: 1, GitFolder: "/", Wait: testGitSyncWait},
 	}
 	resources, err := NewGitSyncResources(gitSyncs)
 	if err != nil {
@@ -212,7 +219,7 @@ func TestNewGitSyncResources_EmptyDirVolume(t *testing.T) {
 
 func TestNewGitSyncResources_Resources(t *testing.T) {
 	gitSyncs := []nifiv1alpha1.GitSyncSpec{
-		{Repo: "https://github.com/example/repo", Branch: "main", Depth: 1, GitFolder: "/", Wait: "20s"},
+		{Repo: testRepoURL, Branch: testGitBranch, Depth: 1, GitFolder: "/", Wait: testGitSyncWait},
 	}
 	resources, err := NewGitSyncResources(gitSyncs)
 	if err != nil {
@@ -240,7 +247,7 @@ func TestNewGitSyncResources_Resources(t *testing.T) {
 
 func TestNewGitSyncResources_Multiple(t *testing.T) {
 	gitSyncs := []nifiv1alpha1.GitSyncSpec{
-		{Repo: "https://github.com/example/repo1", Branch: "main", Depth: 1, GitFolder: "/", Wait: "20s"},
+		{Repo: "https://github.com/example/repo1", Branch: testGitBranch, Depth: 1, GitFolder: "/", Wait: testGitSyncWait},
 		{Repo: "https://github.com/example/repo2", Branch: "develop", Depth: 2, GitFolder: "/nar", Wait: "30s"},
 	}
 
@@ -262,11 +269,11 @@ func TestNewGitSyncResources_Multiple(t *testing.T) {
 
 func TestBuildGitSyncArgs_ContainsSafeDirConfig(t *testing.T) {
 	gs := &nifiv1alpha1.GitSyncSpec{
-		Repo:      "https://github.com/example/repo",
-		Branch:    "main",
+		Repo:      testRepoURL,
+		Branch:    testGitBranch,
 		Depth:     1,
 		GitFolder: "/",
-		Wait:      "20s",
+		Wait:      testGitSyncWait,
 	}
 	args := buildGitSyncArgs(gs, false)
 	found := false


### PR DESCRIPTION
## Summary

Upgrade golangci-lint from v2.8.0 to v2.12.1.

## Changes

- Updated `GOLANGCI_LINT_VERSION` in Makefile to v2.12.1

## Known remaining issues

After running `make lint-fix`, there are 6 `goconst` issues that cannot be auto-fixed:

- `internal/common/git_sync.go:141` - string "main" has 9 occurrences
- `internal/common/git_sync.go:149` - string "20s" has 9 occurrences
- `internal/common/git_sync_test.go:40` - string "https://github.com/example/repo" has 5 occurrences
- `internal/common/git_sync_test.go:41` - string "main" has 9 occurrences
- `internal/common/git_sync_test.go:44` - string "20s" has 9 occurrences
- `internal/common/git_sync_test.go:121` - string "my-git-secret" has 3 occurrences

These should be addressed in a follow-up PR.