### PR TITLE
chore: bump Go from 1.25.5 to 1.25.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/zncdatadev/go-devel:1.25.5-kubedoop0.0.0-dev AS builder
+FROM quay.io/zncdatadev/go-devel:1.25.8-kubedoop0.0.0-dev AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zncdatadev/nifi-operator
 
-go 1.25.5
+go 1.25.8
 
 godebug default=go1.24
 


### PR DESCRIPTION
## Summary
Bump Go version to align with baseline requirement.

## Changes
- go.mod: go 1.25.5 → 1.25.8
- Dockerfile: go-devel:1.25.5 → go-devel:1.25.8

## Testing
- [ ] CI checks pass