### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,144 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+
+env:
+  VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+
+
+jobs:
+  markdown-lint:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v23
+        with:
+          globs: |
+            README.*.md
+            docs/*.md
+
+
+  golang-lint:
+    name: golang-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v9
+
+
+  golang-test:
+    name: Golang Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Running Tests
+        run: |
+          go mod tidy
+          make test
+
+
+  chainsaw-test:
+    name: Chainsaw Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s-version: [
+          '1.35.0'
+        ]
+        product-version: ['2.4.0']
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Create KinD cluster
+        env:
+          KIND_K8S_VERSION: ${{ matrix.k8s-version}}
+          CHAINSAW_KUBECONFIG: kind-kubeconfig-${{ matrix.k8s-version }}
+        run: make setup-chainsaw-cluster
+
+      - name: Chainsaw test setup
+        env:
+          KIND_K8S_VERSION: ${{ matrix.k8s-version }}
+          CHAINSAW_KUBECONFIG: kind-kubeconfig-${{ matrix.k8s-version }}
+        run: make setup-chainsaw-e2e
+
+      - name: Test with Chainsaw
+        env:
+          KIND_K8S_VERSION: ${{ matrix.k8s-version }}
+          CHAINSAW_KUBECONFIG: kind-kubeconfig-${{ matrix.k8s-version }}
+          PRODUCT_VERSION: ${{ matrix.product-version }}
+        run: make chainsaw-e2e
+
+
+  release-image:
+    name: Release Image
+    if: ${{ github.repository_owner == 'zncdatadev' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for OIDC for cosign to automatically use
+    needs:
+      - markdown-lint
+      - golang-lint
+      - golang-test
+      - chainsaw-test
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Cosign
+        uses: sigstore/cosign-installer@main
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Login to quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push operator
+        run: |
+          make docker-buildx
+
+      - name: Sign image
+        run: |
+          IMAGE_NAME=$(jq -r '.["image.name"]' docker-digests.json)
+          IMAGE_DIGEST=$(jq -r '.["containerimage.digest"]' docker-digests.json)
+          IMAGE_REF="${IMAGE_NAME%:*}@${IMAGE_DIGEST}"
+          echo "Signing image: $IMAGE_REF"
+          cosign sign --yes ${IMAGE_REF}


### PR DESCRIPTION
## Summary
Add release workflow for publishing operator images.

## Changes
- Add .github/workflows/release.yml
- Triggered by tag push
- Jobs: Markdown Lint, Golang Lint, Golang Test, Chainsaw Test, Release Image
- Release Image builds multi-arch (amd64/arm64) and signs with Cosign
- NiFi product version: 2.4.0

## Testing
- [ ] Workflow syntax is valid