### PR TITLE
fix: use CR spec productVersion in GetImage() with fallback to default

### DIFF
--- a/internal/controller/cluster/cluster.go
+++ b/internal/controller/cluster/cluster.go
@@ -49,10 +49,15 @@ func NewReconciler(
 }
 
 func (r *Reconciler) GetImage() *util.Image {
+	productVersion := nifiv1alpha1.DefaultProductVersion
+	if r.Spec.Image.ProductVersion != "" {
+		productVersion = r.Spec.Image.ProductVersion
+	}
+
 	image := util.NewImage(
 		nifiv1alpha1.DefaultProductName,
 		version.BuildVersion,
-		nifiv1alpha1.DefaultProductVersion,
+		productVersion,
 		func(options *util.ImageOptions) {
 			options.Custom = r.Spec.Image.Custom
 			options.Repo = r.Spec.Image.Repo


### PR DESCRIPTION
## Description

Previously `GetImage()` hardcoded `DefaultProductVersion`, ignoring the `ProductVersion` field from the CR spec. Now it prioritizes the user-specified value and falls back to the default when unset.

This aligns with the pattern used in zookeeper-operator and hdfs-operator.

## Changes

- `internal/controller/cluster/cluster.go`: Read `r.Spec.Image.ProductVersion` and use it when non-empty, falling back to `nifiv1alpha1.DefaultProductVersion`.

## Testing

- ✅ `go build ./...` passes