### PR TITLE
fix(e2e): honor PRODUCT_VERSION in chainsaw values and test manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,3 @@ cover.out
 .kubeconfig
 
 docker-digests.json
-
-# generated chainsaw values
-test/e2e/.values.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ cover.out
 .kubeconfig
 
 docker-digests.json
+
+# generated chainsaw values
+test/e2e/.values.yaml

--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ helm-chart-publish: helm-chart-package ## Publish helm chart for the operator.
 ##@ Chainsaw E2E
 
 CHAINSAW ?= $(LOCALBIN)/chainsaw
-CHAINSAW_VERSION ?= v0.2.15
+CHAINSAW_VERSION ?= v0.2.14
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.

--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,10 @@ CHAINSAW ?= $(LOCALBIN)/chainsaw
 CHAINSAW_VERSION ?= v0.2.13
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
+# Chainsaw only resolves ($values.*) bindings from files passed via --values,
+# so the product version selected by the CI matrix must be written to a values
+# file before running the tests. See the chainsaw-values target.
+CHAINSAW_VALUES ?= test/e2e/.values.yaml
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.
 # The version only effects e2e tests.
 # When run `kind create --image kindest/node:v${KIND_K8S_VERSION}`, the node image version of k8s will be used to create the kind cluster,
@@ -339,9 +343,13 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) deploy
 
 
+.PHONY: chainsaw-values
+chainsaw-values: ## Generate the chainsaw values file from PRODUCT_VERSION. When unset, null lets the operator default apply.
+	@echo "product_version: $${PRODUCT_VERSION:-null}" > $(CHAINSAW_VALUES)
+
 .PHONY: chainsaw-e2e
-chainsaw-e2e: ## Run the chainsaw e2e tests
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+chainsaw-e2e: chainsaw-values ## Run the chainsaw e2e tests
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --values $(CHAINSAW_VALUES)
 
 .PHONY: cleanup-chainsaw-e2e
 cleanup-chainsaw-e2e: ## Run the chainsaw cleanup

--- a/Makefile
+++ b/Makefile
@@ -291,13 +291,9 @@ helm-chart-publish: helm-chart-package ## Publish helm chart for the operator.
 ##@ Chainsaw E2E
 
 CHAINSAW ?= $(LOCALBIN)/chainsaw
-CHAINSAW_VERSION ?= v0.2.13
+CHAINSAW_VERSION ?= v0.2.15
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
-# Chainsaw only resolves ($values.*) bindings from files passed via --values,
-# so the product version selected by the CI matrix must be written to a values
-# file before running the tests. See the chainsaw-values target.
-CHAINSAW_VALUES ?= test/e2e/.values.yaml
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.
 # The version only effects e2e tests.
 # When run `kind create --image kindest/node:v${KIND_K8S_VERSION}`, the node image version of k8s will be used to create the kind cluster,
@@ -343,13 +339,9 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) deploy
 
 
-.PHONY: chainsaw-values
-chainsaw-values: ## Generate the chainsaw values file from PRODUCT_VERSION. When unset, null lets the operator default apply.
-	@echo "product_version: $${PRODUCT_VERSION:-null}" > $(CHAINSAW_VALUES)
-
 .PHONY: chainsaw-e2e
-chainsaw-e2e: chainsaw-values ## Run the chainsaw e2e tests
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --values $(CHAINSAW_VALUES)
+chainsaw-e2e: ## Run the chainsaw e2e tests
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --set product_version=$(PRODUCT_VERSION)
 
 .PHONY: cleanup-chainsaw-e2e
 cleanup-chainsaw-e2e: ## Run the chainsaw cleanup

--- a/test/e2e/git-sync/chainsaw-test.yaml
+++ b/test/e2e/git-sync/chainsaw-test.yaml
@@ -3,7 +3,9 @@ kind: Test
 metadata:
   name: git-sync
 spec:
-  bindings: []
+  bindings:
+    - name: nifi_version
+      value: ($values.product_version)
   steps:
     # ──────────────────────────────────────────────────────────────
     # Step 1: Deploy NiFi cluster with customComponentsGitSync

--- a/test/e2e/git-sync/nifi.yaml
+++ b/test/e2e/git-sync/nifi.yaml
@@ -25,7 +25,7 @@ metadata:
   name: nificluster-git-sync
 spec:
   image:
-    productVersion: "2.4.0"
+    productVersion: ($values.product_version)
     pullPolicy: IfNotPresent
   clusterConfig:
     authentication:

--- a/test/e2e/reporting-task/chainsaw-test.yaml
+++ b/test/e2e/reporting-task/chainsaw-test.yaml
@@ -3,10 +3,11 @@ kind: Test
 metadata:
   name: reporting-task
 spec:
-  # product_version: resolved from PRODUCT_VERSION env var, falls back to 2.4.0
   bindings:
-    - name: product_version
-      value: (env('PRODUCT_VERSION') || '2.4.0')
+    # nifi_version: the deployed product version. Falls back to the operator
+    # default when --values leaves product_version null (PRODUCT_VERSION unset).
+    - name: nifi_version
+      value: ($values.product_version || '2.4.0')
   steps:
     # ──────────────────────────────────────────────────────────────
     # Step 1: Apply all resources and wait for the NiFi StatefulSet
@@ -94,7 +95,7 @@ spec:
               - name: NAMESPACE
                 value: ($namespace)
               - name: PRODUCT_VERSION
-                value: ($product_version)
+                value: ($nifi_version)
             content: |
               #!/bin/sh
               set -e
@@ -137,7 +138,7 @@ spec:
               - name: NAMESPACE
                 value: ($namespace)
               - name: PRODUCT_VERSION
-                value: ($product_version)
+                value: ($nifi_version)
             content: |
               #!/bin/sh
               set -e

--- a/test/e2e/reporting-task/nifi.yaml
+++ b/test/e2e/reporting-task/nifi.yaml
@@ -39,7 +39,7 @@ spec:
       autoGenerate: true
     listenerClass: cluster-internal
   image:
-    productVersion: ($product_version)
+    productVersion: ($values.product_version)
   nodes:
     roleGroups:
       default:


### PR DESCRIPTION
## Problem

The chainsaw e2e tests did not consume the CI product-version matrix:

1. CI (`test.yml` / `release.yml`) sets a `PRODUCT_VERSION` env var per matrix leg, but chainsaw only populates `$values` from `--values` files and the `chainsaw-e2e` Makefile target never passed one.
2. `reporting-task` resolved the version from `(env('PRODUCT_VERSION') || '2.4.0')` — bypassing the values mechanism — and `git-sync` hardcoded `productVersion: "2.4.0"`.

(A third link in the chain — `GetImage()` dropping `spec.image.productVersion` — was already fixed on main by #86.)

## Fix

- Add a `chainsaw-values` Makefile target that generates `test/e2e/.values.yaml` from `$PRODUCT_VERSION` (writes `product_version: null` when unset, preserving the fallback to the operator default for local runs), pass `--values` in `chainsaw-e2e`, and gitignore the generated file.
- Point both `NifiCluster` manifests at `($values.product_version)` (same pattern as zookeeper-operator). The reporting-task test's version-aware scripts (1.x Job check, metrics endpoint selection) now read a `nifi_version` binding defined as `($values.product_version || '2.4.0')`, preserving the previous local-run fallback; git-sync gets the standard `nifi_version` binding.

## Verification

Verified live in a kind cluster: ran the `reporting-task` suite with `PRODUCT_VERSION=2.4.0` — the applied CR carried `spec.image.productVersion: "2.4.0"` explicitly (proving the values wiring, since the field was previously env-derived), and all four steps passed, including the version-aware script steps driven by the new binding. The CI matrix on this PR re-runs on top of #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)