### PR TITLE
ci: align the release pipeline with the org baseline

### DIFF
--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -1,0 +1,14 @@
+## Reference: https://github.com/helm/chart-testing/blob/master/doc/ct_lint-and-install.md
+# Don't add the 'debug' attribute, otherwise the workflow won't work anymore
+# Only Used for the CT Install Stage
+remote: origin
+target-branch: main
+chart-dirs:
+  - deploy/helm
+chart-repos: []
+helm-extra-args: "--timeout 600s"
+validate-chart-schema: false
+validate-maintainers: false
+validate-yaml: true
+exclude-deprecated: true
+excluded-charts: []

--- a/.github/configs/ct-lint.yaml
+++ b/.github/configs/ct-lint.yaml
@@ -1,0 +1,14 @@
+## Reference: https://github.com/helm/chart-testing/blob/main/doc/ct_lint.md
+# Don't add the 'debug' attribute, otherwise the workflow won't work anymore
+# Only Used for the CT Lint Stage
+remote: origin
+target-branch: main
+chart-dirs:
+  - deploy/helm
+chart-repos: []
+validate-chart-schema: false
+validate-maintainers: false
+validate-yaml: true
+exclude-deprecated: true
+check-version-increment: false
+excluded-charts: []

--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -1,0 +1,151 @@
+## Reference: https://github.com/helm/chart-testing-action
+name: Chart Linting and Testing
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+
+
+env:
+  VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+
+
+jobs:
+  check-crds-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Check CRDs sync
+        run: |
+          # Use `make manifests` to generate the CRDs
+          make manifests
+          # Check if the CRDs are in sync with the manifests.
+          # Stage everything first so newly generated (untracked) files are
+          # detected too; plain `git diff` ignores untracked files.
+          git add -A
+          if ! git diff --cached --exit-code; then
+            echo "CRDs are not in sync with the manifests."
+            echo "Please run 'make manifests' to update the CRDs."
+            exit 1
+          fi
+
+  linter-artifacthub:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    container:
+      image: public.ecr.aws/artifacthub/ah:v1.14.0
+      options: --user 1001
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run ah lint
+        working-directory: deploy/helm
+        run: ah lint
+
+  chart-lint-helm:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Setup Chart Linting
+        id: lint
+        uses: helm/chart-testing-action@v2.8.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --chart-dirs deploy/helm --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --debug --config ./.github/configs/ct-lint.yaml
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.list-changed.outputs.changed == 'true'
+        run: make docker-build
+
+      - name: Load images to cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/nifi-operator:$VERSION
+
+      - name: Run chart-testing (install)
+
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          ct install --config ./.github/configs/ct-install.yaml
+
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Setup Chart Linting
+        id: lint
+        uses: helm/chart-testing-action@v2.8.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --chart-dirs deploy/helm --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Go
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run chart-e2e
+        if: steps.list-changed.outputs.changed == 'true'
+        run: make chart-e2e

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,3 +36,8 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v9
+        with:
+          # Pin the linter version so a new upstream release cannot break the
+          # pipeline without a code change. Keep in sync with the Makefile's
+          # GOLANGCI_LINT_VERSION.
+          version: v2.12.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,124 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+
+
+jobs:
+  publish-image:
+    name: Publish Image
+    if: ${{ github.repository_owner == 'zncdatadev' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Login to quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push operator
+        run: |
+          make docker-buildx
+
+
+  publish-chart:
+    name: Publish Chart
+    if: ${{ github.repository_owner == 'zncdatadev' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+
+      - name: Login to quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_CHART_USERNAME }}
+          password: ${{ secrets.QUAY_CHART_PASSWORD }}
+
+      - name: Build and push oci chart
+        run: |
+          make helm-chart-publish
+
+      - name: Clone helm charts repository
+        uses: actions/checkout@v6
+        with:
+          repository: zncdatadev/kubedoop-helm-charts
+          ref: gh-pages
+          # Use PAT for authentication, must be a repo content rw scope token
+          # Subsequent commits to the repository require read and write permissions
+          token: ${{ secrets.HELM_CHARTS_REPO_TOKEN }}
+          path: kubedoop-helm-charts
+
+      - name: Update helm charts index
+        run: |
+          OCI_REGISTRY="oci://quay.io/kubedoopcharts"
+
+          # Ensure chart index.yaml exists
+          if [ ! -f kubedoop-helm-charts/index.yaml ]; then
+            echo "index.yaml not found"
+            exit 1
+          fi
+
+          # Get chart package file from the target directory, ensuring exactly one exists
+          CHART_PACKAGES=$(ls target/charts/*.tgz)
+          if [ $(echo "$CHART_PACKAGES" | wc -l) -ne 1 ]; then
+            echo "Expected exactly one chart package, found: $CHART_PACKAGES"
+            exit 1
+          fi
+          CHART_PACKAGE=$(basename $CHART_PACKAGES)
+
+          # Extract chart name and version from package filename
+          # Examples:
+          # foo-0.0.0-dev.tgz -> CHART_NAME=foo, CHART_VERSION=0.0.0-dev
+          # foo-12.0.1.tgz -> CHART_NAME=foo, CHART_VERSION=12.0.1
+          # my-chart-2-operator-1.0.0.tgz -> CHART_NAME=my-chart-2-operator, CHART_VERSION=1.0.0
+          # Strategy: Find the last occurrence of -[digit] pattern, that's where version starts
+          CHART_NAME=$(echo $CHART_PACKAGE | sed 's/-[0-9]\+\..*\.tgz$//')
+          CHART_VERSION=$(echo $CHART_PACKAGE | sed "s/^$CHART_NAME-\(.*\)\.tgz$/\1/")
+
+          # Validate extracted CHART_NAME and CHART_VERSION
+          if [ -z "$CHART_NAME" ] || [ -z "$CHART_VERSION" ]; then
+            echo "Failed to extract CHART_NAME or CHART_VERSION from package filename: $CHART_PACKAGE"
+            exit 1
+          fi
+
+          # Regenerate the index.yaml file for the helm charts repository
+          helm repo index --url $OCI_REGISTRY --merge kubedoop-helm-charts/index.yaml target/charts
+          # Replace .tgz in URL with OCI tag (remove .tgz suffix)
+          sed -i "s|$OCI_REGISTRY/$CHART_PACKAGE|$OCI_REGISTRY/$CHART_NAME:$CHART_VERSION|" target/charts/index.yaml
+
+          # Copy the updated index.yaml to the kubedoop-helm-charts directory
+          cp target/charts/index.yaml kubedoop-helm-charts/index.yaml
+
+          # Push index.yaml to the kubedoop-helm-charts repository
+          cd kubedoop-helm-charts
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add index.yaml
+          # Only commit and push if there are changes
+          if ! git diff --cached --quiet; then
+            git commit -m "Update index"
+            git push origin gh-pages
+          else
+            echo "No changes to commit."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,175 @@ jobs:
           fi
 
 
+  chart-linter-artifacthub:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    container:
+      image: public.ecr.aws/artifacthub/ah:v1.14.0
+      options: --user 1001
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run ah lint
+        working-directory: deploy/helm
+        run: ah lint
+
+
+  chart-lint-helm:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Setup Chart Linting
+        id: lint
+        uses: helm/chart-testing-action@v2.8.0
+
+      - name: Fetch all tags and release branches
+        run: |
+          git fetch --tags --force
+          git fetch origin --no-tags '+refs/heads/release-*:refs/remotes/origin/release-*'
+
+      - name: Get commit range
+        id: commit-range
+        run: |
+          # Get current and previous tag
+          # Exclude -dev pre-release tags only when looking for the previous tag,
+          # not when matching the current tag itself
+          CURRENT_TAG="${{ github.ref_name }}"
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1 | grep -v '\-dev$')
+
+          # If the -dev tag itself was the only match (no previous stable tag found),
+          # try again excluding -dev to find the actual previous stable release
+          if [[ -z "$PREVIOUS_TAG" ]]; then
+            PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v '\-dev$' | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          fi
+
+          # First release detection
+          if [[ "$PREVIOUS_TAG" == "$CURRENT_TAG" || -z "$PREVIOUS_TAG" ]]; then
+            echo "First release detected - marking all charts as changed"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "target_branch=main" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Get previous tag commit
+          PREVIOUS_COMMIT=$(git rev-list -n 1 "$PREVIOUS_TAG")
+          echo "Current commit for previous tag ($PREVIOUS_TAG): $PREVIOUS_COMMIT"
+
+          # Get the branch name(s) of the previous commit, prefer release branches, then main, then others
+          PREVIOUS_BRANCHES=$(git branch -r --contains "$PREVIOUS_COMMIT" | sed 's/^[ *]*//')
+          echo "Found branches containing the previous commit: $PREVIOUS_BRANCHES"
+
+          # Define branch priority: release branches (sorted), then main, then others
+          PRIORITY_BRANCH=""
+          # 1. Find release branches (sorted lexicographically)
+          RELEASE_BRANCH=$(echo "$PREVIOUS_BRANCHES" | grep -E 'origin/release' | sort | head -n1)
+          if [[ -n "$RELEASE_BRANCH" ]]; then
+            PRIORITY_BRANCH="$RELEASE_BRANCH"
+          else
+            # 2. Fallback to main
+            MAIN_BRANCH=$(echo "$PREVIOUS_BRANCHES" | grep -E '^origin/main$')
+            if [[ -n "$MAIN_BRANCH" ]]; then
+              PRIORITY_BRANCH="$MAIN_BRANCH"
+            else
+              # 3. Fallback to the first other branch
+              PRIORITY_BRANCH=$(echo "$PREVIOUS_BRANCHES" | head -n1)
+            fi
+          fi
+
+          echo "Removing 'origin/' from branches"
+          PRIORITY_BRANCH=$(echo "$PRIORITY_BRANCH" | sed 's|^origin/||')
+          echo "Selected target branch for comparison: $PRIORITY_BRANCH"
+
+          echo "target_branch=$PRIORITY_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "since_commit=$PREVIOUS_COMMIT" >> "$GITHUB_OUTPUT"
+
+      - name: Check chart changes
+        id: check-changes
+        run: |
+          # Check for changes in chart directory using both --since and --target-branch parameters
+          if ! changed=$(ct list-changed \
+            --chart-dirs deploy/helm \
+            --since "${{ steps.commit-range.outputs.since_commit }}" \
+            --target-branch "${{ steps.commit-range.outputs.target_branch }}"); then
+            echo "Failed to check for changes"
+            exit 1
+          fi
+
+          if [[ -n "$changed" ]]; then
+            echo "Changed charts detected: $changed"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No chart changes detected"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.check-changes.outputs.changed == 'true'
+        run: |
+          ct lint \
+            --since "${{ steps.commit-range.outputs.since_commit }}" \
+            --target-branch "${{ steps.commit-range.outputs.target_branch }}" \
+            --config ./.github/configs/ct-lint.yaml
+
+      - name: Create kind cluster
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.check-changes.outputs.changed == 'true'
+        run: make docker-build
+
+      - name: Load images to cluster
+        if: steps.check-changes.outputs.changed == 'true'
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/nifi-operator:$VERSION
+
+      - name: Run chart-testing (install)
+        if: steps.check-changes.outputs.changed == 'true'
+        run: |
+          ct install \
+            --since "${{ steps.commit-range.outputs.since_commit }}" \
+            --target-branch "${{ steps.commit-range.outputs.target_branch }}" \
+            --config ./.github/configs/ct-install.yaml
+
+
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run chart-e2e
+        run: make chart-e2e
+
+
   release-image:
     name: Release Image
     if: ${{ github.repository_owner == 'zncdatadev' }}
@@ -176,3 +345,93 @@ jobs:
           IMAGE_REF="${IMAGE_NAME%:*}@${IMAGE_DIGEST}"
           echo "Signing image: $IMAGE_REF"
           cosign sign --yes ${IMAGE_REF}
+
+
+  release-chart:
+    name: Release Chart
+    if: ${{ github.repository_owner == 'zncdatadev' }}
+    runs-on: ubuntu-latest
+    needs:
+      - chart-linter-artifacthub
+      - chart-lint-helm
+      - chart-e2e
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Login to quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_CHART_USERNAME }}
+          password: ${{ secrets.QUAY_CHART_PASSWORD }}
+
+      - name: Build and push oci chart
+        run: |
+          make helm-chart-publish
+
+      - name: Clone helm charts repository
+        uses: actions/checkout@v6
+        with:
+          repository: zncdatadev/kubedoop-helm-charts
+          ref: gh-pages
+          # Use PAT for authentication, must be a repo content rw scope token
+          # Subsequent commits to the repository require read and write permissions
+          token: ${{ secrets.HELM_CHARTS_REPO_TOKEN }}
+          path: kubedoop-helm-charts
+
+      - name: Update helm charts index
+        run: |
+          OCI_REGISTRY="oci://quay.io/kubedoopcharts"
+
+          # Ensure chart index.yaml exists
+          if [ ! -f kubedoop-helm-charts/index.yaml ]; then
+            echo "index.yaml not found"
+            exit 1
+          fi
+
+          # Get chart package file from the target directory, ensuring exactly one exists
+          CHART_PACKAGES=$(ls target/charts/*.tgz)
+          if [ $(echo "$CHART_PACKAGES" | wc -l) -ne 1 ]; then
+            echo "Expected exactly one chart package, found: $CHART_PACKAGES"
+            exit 1
+          fi
+          CHART_PACKAGE=$(basename $CHART_PACKAGES)
+
+          # Extract chart name and version from package filename
+          # Examples:
+          # foo-0.0.0-dev.tgz -> CHART_NAME=foo, CHART_VERSION=0.0.0-dev
+          # foo-12.0.1.tgz -> CHART_NAME=foo, CHART_VERSION=12.0.1
+          # my-chart-2-operator-1.0.0.tgz -> CHART_NAME=my-chart-2-operator, CHART_VERSION=1.0.0
+          # Strategy: Find the last occurrence of -[digit] pattern, that's where version starts
+          CHART_NAME=$(echo $CHART_PACKAGE | sed 's/-[0-9]\+\..*\.tgz$//')
+          CHART_VERSION=$(echo $CHART_PACKAGE | sed "s/^$CHART_NAME-\(.*\)\.tgz$/\1/")
+
+          # Validate extracted CHART_NAME and CHART_VERSION
+          if [ -z "$CHART_NAME" ] || [ -z "$CHART_VERSION" ]; then
+            echo "Failed to extract CHART_NAME or CHART_VERSION from package filename: $CHART_PACKAGE"
+            exit 1
+          fi
+
+          # Regenerate the index.yaml file for the helm charts repository
+          helm repo index --url $OCI_REGISTRY --merge kubedoop-helm-charts/index.yaml target/charts
+          # Replace .tgz in URL with OCI tag (remove .tgz suffix)
+          sed -i "s|$OCI_REGISTRY/$CHART_PACKAGE|$OCI_REGISTRY/$CHART_NAME:$CHART_VERSION|" target/charts/index.yaml
+
+          # Copy the updated index.yaml to the kubedoop-helm-charts directory
+          cp target/charts/index.yaml kubedoop-helm-charts/index.yaml
+
+          # Push index.yaml to the kubedoop-helm-charts repository
+          cd kubedoop-helm-charts
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add index.yaml
+          # Only commit and push if there are changes
+          if ! git diff --cached --quiet; then
+            git commit -m "Update index"
+            git push origin gh-pages
+          else
+            echo "No changes to commit."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v9
+        with:
+          # Pin the linter version so a new upstream release cannot break the
+          # pipeline without a code change. Keep in sync with the Makefile's
+          # GOLANGCI_LINT_VERSION.
+          version: v2.12.1
 
 
   golang-test:
@@ -66,6 +71,8 @@ jobs:
     strategy:
       matrix:
         k8s-version: [
+          '1.33.7',
+          '1.34.3',
           '1.35.0'
         ]
         product-version: ['2.4.0']
@@ -98,6 +105,32 @@ jobs:
         run: make chainsaw-e2e
 
 
+  check-crds-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Check CRDs sync
+        run: |
+          # Use `make manifests` to generate the CRDs
+          make manifests
+          # Check if the CRDs are in sync with the manifests.
+          # Stage everything first so newly generated (untracked) files are
+          # detected too; plain `git diff` ignores untracked files.
+          git add -A
+          if ! git diff --cached --exit-code; then
+            echo "CRDs are not in sync with the manifests."
+            echo "Please run 'make manifests' to update the CRDs."
+            exit 1
+          fi
+
+
   release-image:
     name: Release Image
     if: ${{ github.repository_owner == 'zncdatadev' }}
@@ -109,6 +142,7 @@ jobs:
       - golang-lint
       - golang-test
       - chainsaw-test
+      - check-crds-sync
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,9 @@ cover.out
 
 docker-digests.json
 
+# helm charts
+# helm package directory
+target
+
 # AI worktree
 .worktree/

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.8.0
+GOLANGCI_LINT_VERSION ?= v2.12.1
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -339,6 +339,14 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) deploy
 
 
+.PHONY: chart-e2e
+chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run e2e tests with Helm chart deployment
+	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
+	"$(HELM)" upgrade --install --create-namespace --namespace $(PROJECT_NAME) \
+		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait $(PROJECT_NAME) \
+		target/charts/$(PROJECT_NAME)-$(VERSION).tgz
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --set product_version=$(PRODUCT_VERSION)
+
 .PHONY: chainsaw-e2e
 chainsaw-e2e: ## Run the chainsaw e2e tests
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --set product_version=$(PRODUCT_VERSION)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -52,6 +52,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - nifi.kubedoop.dev
   resources:
   - nificlusters
@@ -78,18 +90,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
@@ -104,8 +104,8 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - roles
   - rolebindings
+  - roles
   verbs:
   - create
   - delete

--- a/deploy/helm/nifi-operator/crds/crds.yaml
+++ b/deploy/helm/nifi-operator/crds/crds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: nificlusters.nifi.kubedoop.dev
 spec:
   group: nifi.kubedoop.dev


### PR DESCRIPTION
## Why

Preparing the 0.4.0 release surfaced that nifi-operator's pipeline had drifted
furthest from the org baseline of any operator. Most notably, `release.yml`
built and signed the operator image but had **no chart jobs at all** — tagging a
release would publish an image and no helm chart, so users could not install the
released version with helm.

Measured against the standard template (zookeeper / hdfs), nifi was missing:

- `publish.yml` and `chart-lint-test.yml` entirely (only 3 of the 5 standard workflows)
- five `release.yml` jobs: `check-crds-sync`, `chart-linter-artifacthub`,
  `chart-lint-helm`, `chart-e2e`, `release-chart`

It was the only operator in this state.

## What changed

| Commit | Change |
|---|---|
| `41b831b` | Regenerate RBAC role and helm CRDs with controller-gen v0.19.0 |
| `93c41c9` | Add `check-crds-sync`; restore the full k8s matrix in `release.yml` |
| `511aec8` | Pin golangci-lint to v2.12.1 in the workflows and the Makefile |
| `b93d8b8` | Add the `chart-e2e` target and the chart-testing configs |
| `0ef9a64` | Add the missing `chart-lint-test.yml` and `publish.yml` |
| `4bd6b7c` | Publish the helm chart from the release pipeline |
| `0c057aa` | Ignore the helm package output directory |

Three things worth calling out:

**The committed manifests were stale.** They were generated with controller-gen
v0.17.2 while the Makefile pins v0.19.0, so the tree never matched
`make manifests`. Regenerating produces only rule reordering and the version
annotation bump — no permission or schema change — but it has to land before
`check-crds-sync` is added, or that job fails on pre-existing drift.

**golangci-lint was floating.** `golangci-lint-action` was invoked with no
`version:` input, so CI always installed the newest release. That makes the
pipeline break on an upstream release with no change here, and it silently
diverges from what `make lint` runs locally. Both are now pinned to v2.12.1,
the version the rest of the operators use.

**The k8s matrix was inverted.** `release.yml` had been narrowed to a single
version. Since PR CI now covers only the newest version, the release pipeline is
the one place the full matrix must run.

## Verification

Everything below was actually run locally, not inferred:

| Gate | Result |
|---|---|
| `make lint` (v2.12.1) | 0 issues — the upgrade introduced no new findings |
| `make test` | all packages pass |
| `check-crds-sync` (simulated per the CI logic) | passes on a clean tree |
| `make helm-crd-sync` | no drift |
| **`make chart-e2e`** | **2 passed / 0 failed** (git-sync 264.51s, reporting-task 165.47s) |
| Workflow YAML syntax + job graph | valid; `release-chart` correctly gated on the three chart jobs |
| Job set vs. the standard template | identical |

`chart-e2e` was a full run: create the kind cluster, install the four
`OPERATOR_DEPENDS` operators from OCI, build the image, package the chart,
install the packaged chart with helm, then run the chainsaw suite against it.
That path — the one users actually take — had no coverage here before.

## Note for reviewers

`publish.yml` and `release-chart` need `QUAY_CHART_USERNAME`,
`QUAY_CHART_PASSWORD` and `HELM_CHARTS_REPO_TOKEN`. Since this repo previously
had no jobs using them, **please confirm these secrets are configured before
merging** — otherwise the new jobs will fail at the authentication step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)